### PR TITLE
Build serverless package even on non-master builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           name: Deploy client to s3 bucket
           command: sls client deploy --no-confirm
 
- #############
+#############
 # WORKFLOWS #
 #############
 workflows:
@@ -89,7 +89,7 @@ workflows:
       - test-service
       - test-client
       - build-client
-      - build-serverless-package:
+      - build-serverless-package
 
       # master jobs
       - deploy-hold:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,13 +89,9 @@ workflows:
       - test-service
       - test-client
       - build-client
+      - build-serverless-package:
 
       # master jobs
-      - build-serverless-package:
-          filters:
-            branches:
-              only: master
-
       - deploy-hold:
           filters:
             branches:


### PR DESCRIPTION
Probably a good idea to make sure there's no failures building the
serverless package before merging.