### PR TITLE
Remove 'python3.7' runtime from serverless.yml provider

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,6 @@ service: morning-cd
 
 provider:
   name: aws
-  runtime: python3.7
 
 custom:
   client:


### PR DESCRIPTION
No more python code. Serverless finch for web client deploy doesnt
require a serverless.yml provider runtime.