### PR TITLE
Use open.spotify.com urls instead of spotify uris

### DIFF
--- a/web_client/src/scenes/ListensPage/components/Listen/index.js
+++ b/web_client/src/scenes/ListensPage/components/Listen/index.js
@@ -8,7 +8,7 @@ import Person from './Person.svg';
 const Listen = ({ listen }) => (
   <Container>
     <SimpleRow>
-      <SongLink href={`spotify:track:${listen.song.id}`}>
+      <SongLink href={`https://open.spotify.com/track/${listen.song.id}`} target='_blank'>
         <SongTile {...listen.song} />
       </SongLink>
     </SimpleRow>


### PR DESCRIPTION
open.spotify urls:
1. Still redirect mobile clients directly to the spotify app
2. Redirect web clients to the spotify web player
  * uris would very confusingly select the song on the desktop spotify app, if it was there, otherwise do nothing