### PR TITLE
Reduce time until confident for song search to 1s

### DIFF
--- a/web_client/src/scenes/QuestionPage/SongSelect.tsx
+++ b/web_client/src/scenes/QuestionPage/SongSelect.tsx
@@ -18,7 +18,7 @@ export interface SongSelectProps {
 }
 
 export default function ({ searchSongs, onSongSelected }: SongSelectProps) {
-  const [input, setInput, songs, loading] = useAutocomplete<SongInterface>(searchSongs, 2000);
+  const [input, setInput, songs, loading] = useAutocomplete<SongInterface>(searchSongs, 1000);
   const inputRef = useRef<HTMLInputElement>(null);
 
   function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {


### PR DESCRIPTION
I weirdly like the nice loading icon & slow response time, but it
seems like reducing a bit would be nice for people first visiting the
site so slow loads don't make them say 'hey.. this is loading
slow.. and i dont agree with zach\'s general supposition that
there\'s something peaceful about watching a sun spin'