### PR TITLE
Don't clear timeout

### DIFF
--- a/web_client/src/hooks/useConfidentState.tsx
+++ b/web_client/src/hooks/useConfidentState.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 
 /**
  * Hook to check if state has remained the same for a given period of time.
@@ -9,7 +9,6 @@ export default function useConfidentState<T>(initialState: T, msUntilConfident: 
   const [value, setValue] = useState<T>(initialState);
   const [checkValue, setCheckValue] = useState<T>(initialState);
   const [confident, setConfident] = useState<boolean>(true);
-  const timeoutId = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     if (value === checkValue) {
@@ -20,11 +19,10 @@ export default function useConfidentState<T>(initialState: T, msUntilConfident: 
   function handleValueChanged(newValue: T) {
     setValue(newValue);
     setConfident(false);
-    timeoutId.current = setTimeout(() => setCheckValue(newValue), msUntilConfident);
+    setTimeout(() => setCheckValue(newValue), msUntilConfident);
   }
 
   function handleConfidentForceSet() {
-    timeoutId.current && clearTimeout(timeoutId.current);
     setConfident(true);
   }
 


### PR DESCRIPTION
so i just assumed clearing the timeout would help avoid issues. weirdly this introduced a bug that i haven't put much thought into, but removing all the clear timeout logic fixed the bug.

reproduce:
- using submit song component
- type 'tes'
- let complete by automatic timeout
- type 'test' and immediately click enter to force fetch
- backspace to go back to 'tes'
- hangs indefinitely