### PR TITLE
Clear newListens on sunrise

### DIFF
--- a/web_client/src/App.tsx
+++ b/web_client/src/App.tsx
@@ -88,6 +88,7 @@ export default function App() {
 
   function handleSundialSunrise() {
     setListens([]);
+    setNewListens([]);
     setMoreListensToFetch(false);
   }
 


### PR DESCRIPTION
fixes this scenario:
```feature
Scenario: new listens linger on to next day
  Given I opened morning cd last night
  And new listens were polled
  And I never clicked 'show new listens'
  And the sun rose
  And I submitted a song
  When I click 'show new listens'
  Then I see new listens
  And the listens I see are from last night
```